### PR TITLE
fix(region): Update region handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,15 @@ Create a new connectedcar `client`
 - Note the default ConnectedCar client_id is `9fb503e0-715b-47e8-adfd-ad4b7770f73b`
 
 ```javascript
-const client = connectedcar.AuthClient('9fb503e0-715b-47e8-adfd-ad4b7770f73b');
+const client = connectedcar.AuthClient('9fb503e0-715b-47e8-adfd-ad4b7770f73b', {region: 'US'}); // Region argument is only required if you live outside the United States.
 ```
 
-Use `client.getAccessTokenFromCredentials()` to exchange your user credentials for an
-**token object**. To make any vehicle data request to the Ford Sync Connect API, you'll need to give
-the SDK a valid **access token**.
+- Note: If your region is outside of the US you can pass different region parameters to the User
+  class. Regions: (US, CA, EU, AU)
+
+Use `client.getAccessTokenFromCredentials()` to exchange your user credentials for an **token
+object**. To make any vehicle data request to the Ford Sync Connect API, you'll need to give the SDK
+a valid **access token**.
 
 ```javascript
 const token = await client.getAccessTokenFromCredentials({
@@ -44,25 +47,22 @@ const token = await client.getAccessTokenFromCredentials({
 });
 ```
 
-Access tokens will expire every 2 hours, so you'll need to constantly refresh them by
-calling `client.getAccessTokenFromRefreshToken()`
+Access tokens will expire every 2 hours, so you'll need to constantly refresh them by calling
+`client.getAccessTokenFromRefreshToken()`
 
 ```javascript
 const refreshToken = await client.getAccessTokenFromRefreshToken(token.getRefreshToken());
 ```
 
-With your access token in hand, use `connectedcar.User()` to get a User object
-representing the user.
+With your access token in hand, use `connectedcar.User()` to get a User object representing the
+user.
 
 ```javascript
-const user = connectedcar.User(token.getValue(), 'US'); // Region argument is only required if you live outside the United States.
+const user = connectedcar.User(token.getValue());
 ```
 
-- Note: If your region is outside of the US you can pass different region parameters to the User
-  class. Regions: (US, CA, EU, AU)
-
-Use `user.vehicles()` to return an array of all the vehicles associated with a users
-account. The response will include the **vehicle vin**.
+Use `user.vehicles()` to return an array of all the vehicles associated with a users account. The
+response will include the **vehicle vin**.
 
 ```javascript
 const vehicles = await user.vehicles();
@@ -77,11 +77,8 @@ Now with a **vehicle vin** in hand, use `connectedcar.Vehicle()` to get a Vehicl
 representing the user's vehicle.
 
 ```javascript
-let currentVehicle = connectedcar.Vehicle(vehicleList[0], token.getValue(), 'US'); // Region argument is only required if you live outside the United States.
+let currentVehicle = connectedcar.Vehicle(vehicleList[0], token.getValue());
 ```
-
-- Note: If your region is outside of the US you can pass different region parameters to the Vehicle
-  class. Regions: (US, CA, EU, AU)
 
 Now you can ask the car to do things, or ask it for some data! For example:
 

--- a/src/ConnectedCar.ts
+++ b/src/ConnectedCar.ts
@@ -2,17 +2,24 @@ import {OAuth2Client} from './Authentication/OAuth2Client';
 import {Vehicle} from './Vehicle/Vehicle';
 import {User} from './User/User';
 
+export interface RegionInterface {
+  region: 'US' | 'CA' | 'EU' | 'AU';
+}
+
 /**
  * @class ConnectedCar
  */
 export class ConnectedCar {
+  private static region = 'US';
+
   /**
    * Creates a new OAuth2Client object with the given client id.
    * @param clientId
    * @returns OAuth2Client
    */
-  public static AuthClient(clientId: string): OAuth2Client {
-    return new OAuth2Client(clientId);
+  public static AuthClient(clientId: string, region?: RegionInterface): OAuth2Client {
+    if (region) this.region = region.region;
+    return new OAuth2Client(clientId, this.region);
   }
 
   /**
@@ -21,8 +28,8 @@ export class ConnectedCar {
    * @param accessToken
    * @returns Vehicle
    */
-  public static Vehicle(vehicleVIN: string, accessToken: string, region = 'US'): Vehicle {
-    return new Vehicle(vehicleVIN, accessToken, region);
+  public static Vehicle(vehicleVIN: string, accessToken: string): Vehicle {
+    return new Vehicle(vehicleVIN, accessToken, this.region);
   }
 
   /**
@@ -30,7 +37,7 @@ export class ConnectedCar {
    * @param accessToken
    * @returns User
    */
-  public static User(accessToken: string, region = 'US'): User {
-    return new User(accessToken, region);
+  public static User(accessToken: string): User {
+    return new User(accessToken, this.region);
   }
 }

--- a/src/ConnectedCar.ts
+++ b/src/ConnectedCar.ts
@@ -28,8 +28,10 @@ export class ConnectedCar {
    * @param accessToken
    * @returns Vehicle
    */
-  public static Vehicle(vehicleVIN: string, accessToken: string): Vehicle {
-    return new Vehicle(vehicleVIN, accessToken, this.region);
+  public static Vehicle(vehicleVIN: string, accessToken: string, passedRegion: string): Vehicle {
+    let region = this.region;
+    if (passedRegion) region = passedRegion;
+    return new Vehicle(vehicleVIN, accessToken, region);
   }
 
   /**
@@ -37,7 +39,9 @@ export class ConnectedCar {
    * @param accessToken
    * @returns User
    */
-  public static User(accessToken: string): User {
-    return new User(accessToken, this.region);
+  public static User(accessToken: string, passedRegion: string): User {
+    let region = this.region;
+    if (passedRegion) region = passedRegion;
+    return new User(accessToken, region);
   }
 }

--- a/src/User/User.ts
+++ b/src/User/User.ts
@@ -6,7 +6,7 @@ import {AxiosResponse} from 'axios';
  * @extends Api
  */
 export class User extends Api {
-  constructor(accessToken: string, region: string) {
+  constructor(accessToken: string, region = 'US') {
     super(accessToken, region);
   }
 

--- a/src/Vehicle/Vehicle.ts
+++ b/src/Vehicle/Vehicle.ts
@@ -9,7 +9,7 @@ import {ConnectedCarException} from '../Exceptions/ConnectedCarException';
 export class Vehicle extends Api {
   private vehicleVIN: string;
 
-  constructor(vehicleVIN: string, accessToken: string, region: string) {
+  constructor(vehicleVIN: string, accessToken: string, region = 'US') {
     super(accessToken, region);
     this.vehicleVIN = vehicleVIN;
   }


### PR DESCRIPTION
Update region handling arguments. User and Vehicle endpoints still accept region arguments for older versions. 

```javascript
const client = connectedcar.AuthClient('9fb503e0-715b-47e8-adfd-ad4b7770f73b', {region: 'US'}); // Region argument is only required if you live outside the United States.
```